### PR TITLE
refactor: Simplify documentation workflows to deploy without gh-pages branch

### DIFF
--- a/.github/workflows/docs-unreleased.yaml
+++ b/.github/workflows/docs-unreleased.yaml
@@ -37,21 +37,11 @@ jobs:
       - name: Generate documentation
         run: npm run docs
 
-      - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          path: gh-pages
-
-      - name: Deploy unreleased docs
+      - name: Organize unreleased docs
         run: |
-          # Create gh-pages directory if it doesn't exist
-          mkdir -p gh-pages
-
-          # Copy docs to unreleased directory
-          rm -rf gh-pages/unreleased
-          mkdir -p gh-pages/unreleased
-          cp -r docs/* gh-pages/unreleased/
+          # Create deployment structure
+          mkdir -p deploy/unreleased
+          cp -r docs/* deploy/unreleased/
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
@@ -59,7 +49,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './gh-pages'
+          path: './deploy'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -41,28 +41,21 @@ jobs:
       - name: Generate documentation
         run: npm run docs
 
-      - name: Checkout gh-pages branch
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          path: gh-pages
-
       - name: Organize versioned docs
         run: |
-          # Create gh-pages directory if it doesn't exist
-          mkdir -p gh-pages
+          # Create deployment structure
+          mkdir -p deploy
 
           # Copy current docs to versioned directory
-          mkdir -p "gh-pages/v${{ steps.version.outputs.version }}"
-          cp -r docs/* "gh-pages/v${{ steps.version.outputs.version }}/"
+          mkdir -p "deploy/v${{ steps.version.outputs.version }}"
+          cp -r docs/* "deploy/v${{ steps.version.outputs.version }}/"
 
-          # Update or create latest symlink/copy
-          rm -rf gh-pages/latest
-          cp -r docs/* gh-pages/latest 2>/dev/null || mkdir -p gh-pages/latest
-          cp -r docs/* gh-pages/latest/
+          # Copy to latest directory
+          mkdir -p deploy/latest
+          cp -r docs/* deploy/latest/
 
-          # Create index page listing all versions
-          cat > gh-pages/index.html << 'EOF'
+          # Create index page that redirects to latest
+          cat > deploy/index.html << 'EOF'
           <!DOCTYPE html>
           <html>
           <head>
@@ -81,7 +74,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './gh-pages'
+          path: './deploy'
 
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
## Summary

Simplifies both documentation deployment workflows to generate and deploy directly to GitHub Pages without using a gh-pages branch for storage.

## Changes

### docs-unreleased.yaml (Main Branch)
- Removed gh-pages branch checkout step
- Creates `deploy/unreleased/` directory locally
- Deploys directly from artifact

### docs.yaml (Releases)
- Removed gh-pages branch checkout step
- Creates versioned structure locally in `deploy/` directory:
  - `/v{version}/` - versioned documentation
  - `/latest/` - always points to newest release
  - `/index.html` - redirects to latest
- Deploys directly from artifact

## Benefits

- **Cleaner repository**: No generated files in git history
- **Simpler workflows**: Reduced from 89 lines to 82 lines (docs.yaml) and 67 lines to 57 lines (docs-unreleased.yaml)
- **No branch management**: No need to maintain gh-pages branch
- **Fixes deployment failures**: Resolves errors when gh-pages branch doesn't exist
- **Rebuild capability**: Can still rebuild docs from any commit by checking out and running `npm run docs`

## Testing

- All 42 tests passing
- All linters passing
- Pre-commit hooks passing
- Workflows validated for syntax

## Resolves

Closes #11

## Related

- Fixes workflow failure: https://github.com/theroyalwhee0/commonprops/actions/runs/19047977770
- Part of release infrastructure from PR #10