### PR TITLE
chore: Bump version to v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2025-11-03
+## [0.1.1] - 2025-11-03
 
 ### Added
 
@@ -26,5 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Community documentation (CODE_OF_CONDUCT.md, CONTRIBUTING.md, SECURITY.md)
 - CHANGELOG.md to track project changes
 
-[Unreleased]: https://github.com/theroyalwhee0/commonprops/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/theroyalwhee0/commonprops/releases/tag/v0.1.0
+## [0.1.0] - 2025-11-03 [YANKED]
+
+- Unreleased.
+
+[Unreleased]: https://github.com/theroyalwhee0/commonprops/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/theroyalwhee0/commonprops/releases/tag/v0.1.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theroyalwhee0/commonprops",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TypeScript utilities for extracting common properties from sets of types.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Bumps version from 0.1.0 to 0.1.1 due to immutable release restrictions preventing re-tagging of v0.1.0.

## Changes

### package.json
- Update version to 0.1.1

### CHANGELOG.md
- Move all features to v0.1.1 release section (the actual first release)
- Mark v0.1.0 as [YANKED] with note "Unreleased"
- Update version comparison links to use v0.1.1

## Rationale

The v0.1.0 tag was created before deployment workflow fixes were merged. Due to repository rules preventing tag modification, we're skipping to v0.1.1 for the actual first release.

## Validation

✅ All tests passing (42 tests)
✅ All linters passing
✅ Pre-commit hooks passing
✅ Documentation generated successfully

## Resolves

Closes #20