### PR TITLE
fix: Copy hidden files (.nojekyll) in documentation workflows

### DIFF
--- a/.github/workflows/docs-unreleased.yaml
+++ b/.github/workflows/docs-unreleased.yaml
@@ -36,9 +36,9 @@ jobs:
 
       - name: Organize unreleased docs
         run: |
-          # Create deployment structure
+          # Create deployment structure (including hidden files like .nojekyll)
           mkdir -p deploy/unreleased
-          cp -r docs/* deploy/unreleased/
+          cp -r docs/. deploy/unreleased/
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -43,13 +43,13 @@ jobs:
           # Create deployment structure
           mkdir -p deploy
 
-          # Copy current docs to versioned directory
+          # Copy current docs to versioned directory (including hidden files)
           mkdir -p "deploy/v${{ steps.version.outputs.version }}"
-          cp -r docs/* "deploy/v${{ steps.version.outputs.version }}/"
+          cp -r docs/. "deploy/v${{ steps.version.outputs.version }}/"
 
-          # Copy to latest directory
+          # Copy to latest directory (including hidden files)
           mkdir -p deploy/latest
-          cp -r docs/* deploy/latest/
+          cp -r docs/. deploy/latest/
 
           # Create index page that redirects to latest
           cat > deploy/index.html << 'EOF'


### PR DESCRIPTION
## Summary

Fixes the issue where `/latest/` and `/v0.1.2/` documentation paths were not appearing on GitHub Pages, while `/unreleased/` worked correctly.

## Root Cause

Both documentation workflows used `cp -r docs/*` which does not include hidden files. The `.nojekyll` file generated by TypeDoc is required by GitHub Pages to bypass Jekyll processing. Without it, directories were being ignored.

## Changes

Changed `cp -r docs/*` to `cp -r docs/.` in both workflows to include hidden files:
- `.github/workflows/docs.yaml` - Release documentation 
- `.github/workflows/docs-unreleased.yaml` - Unreleased documentation

## Impact

After this fix, all documentation paths should work:
- `/latest/` - Latest release docs
- `/v0.1.2/` - Versioned release docs  
- `/unreleased/` - Main branch docs
- `/` - Root redirect to latest

## Testing

Will need to merge and manually trigger the release docs workflow to verify the fix works.

## Resolves

Closes #24