### PR TITLE
Check for version tag instead of event type in docs workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: current
+          fetch-depth: 0  # Fetch all history and tags
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -41,13 +42,18 @@ jobs:
         working-directory: current
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
 
-      - name: Determine trigger type
+      - name: Check for version tag
         id: trigger
+        working-directory: current
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
+          # Check if current commit has a v* tag
+          TAGS=$(git tag --points-at HEAD | grep '^v')
+          if [ -n "$TAGS" ]; then
             echo "is_release=true" >> $GITHUB_OUTPUT
+            echo "Found version tag(s) on current commit: $TAGS"
           else
             echo "is_release=false" >> $GITHUB_OUTPUT
+            echo "No version tags found on current commit"
           fi
 
       - name: Generate documentation
@@ -82,35 +88,6 @@ jobs:
             rm -rf latest
             cp -r "v${LATEST_VERSION}" latest
 
-            # Update index.html to redirect to latest
-            cat > index.html << 'EOF'
-          <!DOCTYPE html>
-          <html>
-          <head>
-            <title>CommonProps Documentation</title>
-            <meta http-equiv="refresh" content="0; url=./latest/">
-          </head>
-          <body>
-            <p>Redirecting to <a href="./latest/">latest documentation</a>...</p>
-          </body>
-          </html>
-          EOF
-          else
-            # Regular commit: Only unreleased/ was updated
-            # Update index.html to redirect to unreleased
-            cd gh-pages
-            cat > index.html << 'EOF'
-          <!DOCTYPE html>
-          <html>
-          <head>
-            <title>CommonProps Documentation</title>
-            <meta http-equiv="refresh" content="0; url=./unreleased/">
-          </head>
-          <body>
-            <p>Redirecting to <a href="./unreleased/">unreleased documentation</a>...</p>
-          </body>
-          </html>
-          EOF
           fi
 
       - name: Commit and push to gh-pages


### PR DESCRIPTION
## Summary

Updates the docs workflow to check if the current commit has a `v*` tag instead of checking the GitHub event type. This provides more flexibility for documentation generation.

## Changes

**Tag Detection:**
- Replaced `github.event_name` check with `git tag --points-at HEAD`
- Filters for tags starting with 'v'
- Sets `is_release=true` if any v* tags found on current commit

**Fetch Depth:**
- Added `fetch-depth: 0` to checkout step to ensure all tags are available

**Index Page:**
- Removed index.html generation from workflow
- Index page managed directly in gh-pages branch (always redirects to latest/)

## Benefits

- Manual workflow runs on tagged commits can generate versioned docs
- Rebuilding docs for a specific version by running workflow on that tag
- More flexible documentation generation regardless of trigger method

## Test Plan

- [ ] Merge PR and verify docs workflow runs on push to main
- [ ] Verify unreleased/ is updated (no tag on commit)
- [ ] Tag a commit with v* and run workflow manually
- [ ] Verify versioned directory created and latest/ updated

Resolves #31