### PR TITLE
Fix grep failure in docs workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -47,7 +47,7 @@ jobs:
         working-directory: current
         run: |
           # Check if current commit has a v* tag
-          TAGS=$(git tag --points-at HEAD | grep '^v')
+          TAGS=$(git tag --points-at HEAD | grep '^v' || true)
           if [ -n "$TAGS" ]; then
             echo "is_release=true" >> $GITHUB_OUTPUT
             echo "Found version tag(s) on current commit: $TAGS"


### PR DESCRIPTION
## Problem

PR #32 introduced a bug where the docs workflow fails when checking for version tags on commits without tags. The grep command returns exit code 1 when no match is found, causing the workflow to fail due to bash's `-e` flag.

## Fix

Add `|| true` to the grep command to ensure it always returns exit code 0, even when no tags are found.

## Changes

```bash
TAGS=$(git tag --points-at HEAD | grep '^v' || true)
```

This allows the workflow to continue and correctly set `is_release=false` when no version tags are present.

## Test

This will be tested when the PR is merged and the workflow runs on main.