### PR TITLE
Add version-specific titles to TypeDoc documentation

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -58,7 +58,12 @@ jobs:
 
       - name: Generate documentation
         working-directory: current
-        run: npm run docs
+        run: |
+          if [ "${{ steps.trigger.outputs.is_release }}" = "true" ]; then
+            npx typedoc --name "CommonProps Documentation - v${{ steps.version.outputs.version }}" --includeVersion false
+          else
+            npx typedoc --name "CommonProps Documentation - Unreleased" --includeVersion false
+          fi
 
       - name: Checkout gh-pages branch
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ type UpcastCommon = CommonUpcastProps<[Cat, Dog]>; // { name: string; type: stri
 
 ## API
 
-[API documentation](https://theroyalwhee0.github.io/commonprops/latest/)
+Full API documentation is available at:
+
+- **[Latest Release](https://theroyalwhee0.github.io/commonprops/latest/)** - Documentation for the most recent stable release
+- **[Unreleased](https://theroyalwhee0.github.io/commonprops/unreleased/)** - Documentation for the current main branch (may include unreleased features)
 
 ### Main Types
 


### PR DESCRIPTION
## Summary

- Generate different documentation titles for releases vs unreleased builds
- Released: "CommonProps Documentation - v0.1.2"
- Unreleased: "CommonProps Documentation - Unreleased"

## Changes

- Update docs workflow to pass `--name` and `--includeVersion false` flags to TypeDoc
- Use existing `is_release` detection to conditionally set documentation title
- Version is dynamically inserted from package.json for release builds

## Testing

Tested locally with both formats:
- [x] `npx typedoc --name "CommonProps Documentation - Unreleased" --includeVersion false`
- [x] `npx typedoc --name "CommonProps Documentation - v0.1.2" --includeVersion false`
- [x] Verified page titles render correctly in generated HTML
- [x] Pre-commit hooks pass (linting, tests, docs generation)

## Benefits

- Clear distinction between stable releases and development documentation
- Users can easily identify which version they're viewing
- Maintains consistency with versioned documentation directories

Resolves #37